### PR TITLE
bump to marshmallow=3.0.0b20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask>=1.0', 'marshmallow==3.0.0b8'
+        'Flask>=1.0', 'marshmallow==3.0.0b20'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
这个版本应该可以兼容到python3.10 , 而且不需要下游 (moeflow-backend) 改代码

见 https://github.com/kozzzx/flask-apikit/issues/2 的研究